### PR TITLE
Add rectangleCollision local reference

### DIFF
--- a/bin/bump.js
+++ b/bin/bump.js
@@ -1212,6 +1212,7 @@ var Bump = (function () {
           movingCircleCollision = this.movingCircleCollision.bind(this),
           circleCollision = this.circleCollision.bind(this),
           hitTestCircleRectangle = this.hitTestCircleRectangle.bind(this),
+          rectangleCollision = this.rectangleCollision.bind(this),
           circleRectangleCollision = this.circleRectangleCollision.bind(this);
 
       var collision = undefined,

--- a/src/bump.js
+++ b/src/bump.js
@@ -1132,6 +1132,7 @@ class Bump {
         movingCircleCollision = this.movingCircleCollision.bind(this),
         circleCollision = this.circleCollision.bind(this),
         hitTestCircleRectangle = this.hitTestCircleRectangle.bind(this),
+        rectangleCollision = this.rectangleCollision.bind(this),
         circleRectangleCollision = this.circleRectangleCollision.bind(this);
 
     let collision,


### PR DESCRIPTION
I found the following call fails:

b.hit( texture1, texture2, true);

With this console error:

ReferenceError: rectangleCollision is not defined
