### PR TITLE
simple fix where variable was being refered to as o instead of sprite

### DIFF
--- a/src/bump.js
+++ b/src/bump.js
@@ -44,7 +44,7 @@ class Bump {
         "xAnchorOffset": {
           get(){
             if (sprite.anchor !== undefined) {
-              return o.height * o.anchor.x;
+              return sprite.height * sprite.anchor.x;
             } else {
               return 0;
             }
@@ -54,7 +54,7 @@ class Bump {
         "yAnchorOffset": {
           get(){
             if (sprite.anchor !== undefined) {
-              return o.width * o.anchor.y;
+              return sprite.width * sprite.anchor.y;
             } else {
               return 0;
             }


### PR DESCRIPTION
Hey found this issue while using your lib for a small game.

