### PR TITLE
Fixed typos on 'xAnchorOffset' and 'yAnchorOffset' properties 

### DIFF
--- a/src/bump.js
+++ b/src/bump.js
@@ -72,7 +72,7 @@ class Bump {
       
       //xAnchorOffset
       if (sprite.xAnchorOffset === undefined) {
-        Object.defineProperty(sprite, "xAnchorOffset ", {
+        Object.defineProperty(sprite, "xAnchorOffset", {
           get(){
             if (sprite.anchor !== undefined) {
               return sprite.height * sprite.anchor.x;
@@ -86,7 +86,7 @@ class Bump {
       
       //yAnchorOffset
       if (sprite.yAnchorOffset === undefined) {
-        Object.defineProperty(sprite, "yAnchorOffset ", {
+        Object.defineProperty(sprite, "yAnchorOffset", {
           get(){
             if (sprite.anchor !== undefined) {
               return sprite.width * sprite.anchor.y;


### PR DESCRIPTION
There was a trailing space character in both these properties, this made hit testing fail when using sprites where anchor is set. (BTW - love this library :) )