### PR TITLE
Fixed anchorX, anchorY

### DIFF
--- a/src/bump.js
+++ b/src/bump.js
@@ -70,7 +70,7 @@ class Bump {
         Object.defineProperty(sprite, "xAnchorOffset", {
           get(){
             if (sprite.anchor !== undefined) {
-              return sprite.height * sprite.anchor.x;
+              return sprite.width * sprite.anchor.x;
             } else {
               return 0;
             }
@@ -84,7 +84,7 @@ class Bump {
         Object.defineProperty(sprite, "yAnchorOffset", {
           get(){
             if (sprite.anchor !== undefined) {
-              return sprite.width * sprite.anchor.y;
+              return sprite.height * sprite.anchor.y;
             } else {
               return 0;
             }


### PR DESCRIPTION
I had some issues when I changed the sprites anchor point, if the anchor point is different to 0 the collision is not exact

Idk if is a bug, but now works well on any anchor position

PD: I cant build the project on this machine, I just made changes on src/bump.js